### PR TITLE
AI will choose player by random if there are players with the same amount of influences and money

### DIFF
--- a/ai-player.js
+++ b/ai-player.js
@@ -29,8 +29,6 @@ var rankedRoles = ['duke', 'assassin', 'captain', 'inquisitor', 'contessa', 'amb
 // http://random-name-generator.info/
 var aiPlayerNames = fs.readFileSync(__dirname + '/names.txt', 'utf8').split(/\r?\n/);
 
-var node_modules = require('child_process').execSync('npm ls');
-
 function createAiPlayer(game, options) {
     options = extend({
         moveDelay: 0,           // How long the AI will "think" for before playing its move (ms)
@@ -519,6 +517,8 @@ function createAiPlayer(game, options) {
                 indices.push(i);
             }
         }
+        var randomNumber = rand(1000000000000000);
+
         return indices.sort(function (a, b) {
             var infa = state.players[a].influenceCount;
             var infb = state.players[b].influenceCount;
@@ -527,12 +527,9 @@ function createAiPlayer(game, options) {
                 return infb - infa;
             } else if (state.players[b].cash != state.players[a].cash) {
                 return state.players[b].cash - state.players[a].cash;
-            } else { // if both players have the same amount of influences and cash then choose one "by random"
+            } else { // if both players have the same amount of influences and cash then choose one by random
                 // player names are used so that MD5 hashes are different for each player
-                // node modules are used so players couldn't calculate MD5s themselves since the modules are on server side
-                // date is used so MD5 for each username is different every day; otherwise some usernames might never be chosen by AI
-                return md5(new Date().toJSON().slice(0,10) + state.players[a].name + node_modules)
-                    < md5(new Date().toJSON().slice(0,10) + state.players[b].name + node_modules) ? -1 : 1;
+                return md5(randomNumber + state.players[a].name) < md5(randomNumber + state.players[b].name) ? -1 : 1;
             }
         });
         return indices;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "random-seed": "^0.2.0",
     "socket.io": "^1.7.2",
     "validator": "^3.40.0",
-    "winston": "winstonjs/winston#61b4e4093a"
+    "winston": "winstonjs/winston#61b4e4093a",
+    "md5": "^2.2.1"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
Sometimes I can make a decision based on knowing that AI will assasinate or coup the first player from the list if there is more than 1 player with most incluences and cash.
I think I shouldn't be able to do that and that AIs should be less predictable.
For more explanation check out comments in sort function.

After pulling this, a `npm install` is needed as I added a new module "md5" for calculating hash functions.