### PR TITLE
[CODE REVIEW] Half working version of Coup: Reformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Treason Coup
 
 A clone of the card game Coup written in Node.js. Play online at http://treason.thebrown.net.
 
-To run the server locally, you will need to install CouchDB. On Windows, download and run the installer. On Linux, install using your package manager, e.g.:
+To run the server locally, you will need to install CouchDB. On Windows, download and run the installer. On Mac OS X, go to https://couchdb.apache.org/ and download the APP file, placing it in your Applications folder. On Linux, install using your package manager, e.g.:
 
     sudo apt-get install couchdb
 

--- a/game-tracker.js
+++ b/game-tracker.js
@@ -163,6 +163,15 @@ GameTracker.prototype.encodeAction = function (action, target) {
     else if (action === 'income') {
         return (8+5) << 4;
     }
+    else if (action == 'apostatize') {
+        return 6 << 4;
+    }
+    else if (action == 'conversion') {
+        return 7 << 4 | (target & 0xf);
+    }
+    else if (action == 'embezzlement') {
+        return (8+6) << 4;
+    }
 };
 
 GameTracker.prototype.unpack = function (buffer, gameInfo) {
@@ -266,6 +275,15 @@ GameTracker.prototype.decodeActionEvent = function (actionCode) {
             break;
         case 8+5:
             action = 'income';
+            break;
+        case 6:
+            action = 'apostatize';
+            break;
+        case 7:
+            action = 'conversion';
+            break;
+        case 8+6:
+            action = 'embezzlement';
             break;
     }
     var event = {

--- a/game.js
+++ b/game.js
@@ -446,8 +446,7 @@ module.exports = function createGame(options) {
                 var influence = masked.players[i].influence;
                 for (var j = 0; j < influence.length; j++) {
                     if (!influence[j].revealed) {
-                        influence[j].role = influence[j].role;
-                        //influence[j].role = 'unknown';
+                        influence[j].role = 'unknown';
                     }
                 }
             }

--- a/views/partials/game-actions.ejs
+++ b/views/partials/game-actions.ejs
@@ -8,6 +8,7 @@
             <br/>
             <button class="btn btn-default" data-bind="event: {vclick: start.bind(null, 'original')}, enable: canStartGame">Start normal game</button>
             <button class="btn btn-default" data-bind="event: {vclick: start.bind(null, 'inquisitors')}, enable: canStartGame">Start inquisitor game</button>
+            <button class="btn btn-default" data-bind="event: {vclick: start.bind(null, 'reformation')}, enable: canStartGame">Start reformation game</button>
         </p>
         <p data-bind="visible: wantToStart()">
             Not all players are ready. Start without them?<br/>
@@ -34,9 +35,18 @@
             <!-- ko foreach: actionNames() -->
                 <!-- ko if: actionPresentInGame($data) -->
                     <button class="btn btn-action" data-bind="enable: canPlayAction($data), event: {vclick: playAction}, css: buttonActionClass($data)">
-                        <i data-bind="css: $data"></i>
-                        <span data-bind="text: $data"></span>
+                        <!-- ko if: $data != 'embezzlement' -->
+                            <i data-bind="css: $data"></i>
+                            <span data-bind="text: $data"></span>
+                        <!-- /ko -->
+                        <!-- ko if: $data == 'embezzlement' -->
+                            <span class="badge" style="margin-top: 9px; margin-bottom: 8px;" data-bind="text: '$' + $root.state.treasuryReserve()"></span>
+                            <span data-bind="text: $data"></span>
+                        <!-- /ko -->
                     </button>
+                <!-- /ko -->
+                <!-- ko if: $data == 'coup' -->
+                    <br>
                 <!-- /ko -->
             <!-- /ko -->
         <!-- /ko -->

--- a/views/partials/side-bar.ejs
+++ b/views/partials/side-bar.ejs
@@ -1,5 +1,5 @@
 <ul class="list-group" data-bind="foreach: state.players">
-    <li class="list-group-item" data-bind="css: { 'current-player' : $index() == $root.state.state.playerIdx() }">
+    <li class="list-group-item" data-bind="css: { 'current-player' : $index() == $root.state.state.playerIdx(), 'catholic-player': $root.state.players()[$index()].team() == 1, 'protestant-player': $root.state.players()[$index()].team() == -1, 'dead-team' : influenceCount() == 0 }">
         <div class="row" data-bind="visible: $root.waitingToPlay">
             <div class="col-xs-6">
                 <span data-bind="text: name, css: { 'dead-player' : isReady() == 'observe' }"></span>

--- a/web/client.css
+++ b/web/client.css
@@ -160,6 +160,15 @@ div.chat {
 .current-player {
     border-left: 5px solid black;
 }
+.catholic-player {
+    border-right: 5px solid darkred;
+}
+.protestant-player {
+    border-right: 5px solid navy;
+}
+.dead-team {
+    border-right: 5px solid #aaa !important;
+}
 .dead-player {
     color: #aaa;
 }

--- a/web/shared.js
+++ b/web/shared.js
@@ -40,6 +40,17 @@
             cost: 0,
             roles: 'inquisitor',
             targeted: true
+        },
+        'apostatize': {
+            cost: 1
+        },
+        'conversion': {
+            cost: 2,
+            targeted: true
+        },
+        'embezzlement': {
+            cost: 0
+            //,roles: '!duke'
         }
     };
 


### PR DESCRIPTION
EDIT: Sorry! I just saw the very hidden "Create draft pull request" option after I created this pull request. It's really stupid that GitHub hides that functionality. I should have made this pull request a draft.

I'm creating this Pull Request with the intent that it will either linger here until I can fully implement Coup: Reformation, or if you create a coup-reformation branch, I could move my pull request to that branch instead (or if I can't update this pull request, reject it so that I can create a new one).

Long story short, I've implemented half of Coup: Reformation. I based this on the original version of Coup: Reformation which had Catholic and Protestant Teams. Here are my changes:

- Added Apostatize, Conversion, and Embezzlement actions. The "apostatize" and "conversion" actions are both "conversion", but the way this code is written, I had to separate out the 1 coin convert yourself, from the 2 coin convert someone else
- Increased maximum players to 10. I could not find an easy way to switch between 6 players for ambassador/inquisitor (could not remove excess AI players from game), so all gamemodes can support 10 players now
- Added treasury reserve logic to the game. Treasury reserve shows up in the bubble next to embezzlement
- Added Catholic/Protestant teams to the game. Players will be set to a dead team when they lose all influences
- Allow players to apostatize and convert alongside coup when they have >$9
- Players on the same team cannot target each other (steal, assassinate), but they can still challenge each other
- AI players can use and bluff embezzlement
- Added deck support for players greater than 6. Can theoretically support an infinite number of players as it will continue to add cards to the deck for each 2 players in the game

Not implemented yet:
- Players on the same team can still block foreign aid
- AI logic for apostatizing and converting
- Cannot challenge embezzlement

Here are my thoughts on the four current issues I see with this code:
- What should the apostatize and conversion icons be?
- Should Coup: Reformation have two gamemodes, one for ambassadors, and one for inquisitors?
- Instead of "Start X game", the buttons should set the gamemode, which will set the roles and players, and then a second button starts the game. This will allow toggling between a maximum of 6 players, 8 players, 10 players, etc.
- I looked into foreign aid, but couldn't find where I'd need to put the code to prevent team members from blocking foreign aid from each other
- We will need two versions of the strongestPlayer function, one that finds strongest player on team, and another that finds strongest player in-game. Another function will have to aggregate the strength of each team, and if the other team is stronger than your own power, convert. Otherwise, if the other team is only as strong as your own power, apostatize.