### PR TITLE
Unique playerId per player

### DIFF
--- a/dataaccess-fake.js
+++ b/dataaccess-fake.js
@@ -4,7 +4,7 @@ module.exports = {
     // Called when the server initially starts
     init: () => Promise.resolve(),
     // Called when a new player logs in for the first time or an existing player changes their name
-    register: id => id || Promise.resolve(crypto.randomBytes(16).toString('hex')),
+    register: id => Promise.resolve(id || crypto.randomBytes(16).toString('hex')),
     // Called at the start of a game
     constructGameStats: () => {
         return {

--- a/dataaccess-fake.js
+++ b/dataaccess-fake.js
@@ -1,8 +1,10 @@
+var crypto = require('crypto');
+
 module.exports = {
     // Called when the server initially starts
     init: () => Promise.resolve(),
     // Called when a new player logs in for the first time or an existing player changes their name
-    register: id => Promise.resolve(id),
+    register: id => id || Promise.resolve(crypto.randomBytes(16).toString('hex')),
     // Called at the start of a game
     constructGameStats: () => {
         return {


### PR DESCRIPTION
The playerId needs to be generated for the player by the server, if the player isn't providing one themselves already. Using the classic anti pattern of 'navigation by exception', I had originally attempted a couch key lookup directly of the provided playerId and if that failed, assigned them a fresh one in the catch block.

To fix this, the dummy data-access now also generates an Id if one isn't provided already.