### PR TITLE
Clear dead games

### DIFF
--- a/game.js
+++ b/game.js
@@ -83,7 +83,15 @@ module.exports = function createGame(options) {
     game._test_setDeck = _test_setDeck;
     game._test_resetAllows = resetAllows;
 
+    //The game is created but relies on the creating player joining. If they fail to join after a few minutes, assume
+    //they timed out and reap game.
+    var reaperHandle = setTimeout(function () {
+        debug('No players joined, destroying game');
+        destroyGame();
+    }, 120000);
+
     function playerJoined(playerIface) {
+        clearTimeout(reaperHandle);
         var isObserver;
         if (countReadyPlayers() < MAX_PLAYERS) {
             isObserver = false;


### PR DESCRIPTION
When a player creates a game, that game sticks around until the player joins. If the player fails to join (socket timeout, browser/script abort due to multiple submissions or name validation check, etc), the game remains active. If the creator also password protected the game, then no other player can join the game to 'revive' it and it sticks around forever. This is why we only saw dead games with passwords - the ones without would have been revived and garbage collected by other players joining and leaving them.